### PR TITLE
v1.6.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 ## 1.6.0 (2026-06-02)
-* Simpliefies working with lists of PII locations. Fixes bug introduced in v1.5.0 where Pixel processing could be skipped for certain bouncer configurations.
+* Simplifies working with lists of PII locations. Fixes bug introduced in v1.5.0 where Pixel processing could be skipped for certain bouncer configurations.
 
 ## 1.5.0 (2026-02-25)
 * Adds ReplaceAndReuse Operator that calls separate generator function for dummy value. See #151 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,7 @@
 # History
+## 1.6.0 (2026-06-02)
+* Simpliefies working with lists of PII locations. Fixes bug introduced in v1.5.0 where Pixel processing could be skipped for certain bouncer configurations.
+
 ## 1.5.0 (2026-02-25)
 * Adds ReplaceAndReuse Operator that calls separate generator function for dummy value. See #151 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idiscore"
-version = "1.5.0"
+version = "1.6.0"
 description = "Pure-python deidentification of DICOM images using Attribute Confidentiality Options"
 authors = [{ name = "sjoerdk", email = "sjoerd.kerkstra@radboudumc.nl" }]
 readme = "README.md"


### PR DESCRIPTION
## 1.6.0 (2026-06-02)
* Simplifies working with lists of PII locations. Fixes bug introduced in v1.5.0 where Pixel processing could be skipped for certain bouncer configurations.